### PR TITLE
Fix actions receiving nil instance

### DIFF
--- a/src/apply.luau
+++ b/src/apply.luau
@@ -14,7 +14,7 @@ type Node<T> = graph.Node<T>
 local event_buffer: { [string]: () -> () } = {}
 
 -- buffer of priority -> callback to run after events are connected
-local action_buffers = {} :: { { () -> () } }
+local action_buffers = {} :: { { (Instance) -> () } }
 setmetatable(action_buffers :: any, {
     __index = function(_, i: number)
         action_buffers[i] = {}
@@ -131,7 +131,7 @@ local function apply<T>(instance: T & Instance, properties: { [unknown]: unknown
     -- run buffered actions respecting their priorities
     for _, buffer in next, action_buffers do
         for _, callback in next, buffer do
-            callback()
+            callback(instance)
         end
     end
 


### PR DESCRIPTION
Action callbacks are called with `nil` instead of the instance they were applied to. This PR updates the buffered action type to `(Instance) -> ()` and passes `instance` to the action callback.

This likely slipped by since the action tests don't include checking the instance passed to the action callback, so adding checks for this could help, too.