### PR TITLE
Fix `switch` return type not resolving correctly

### DIFF
--- a/src/switch.luau
+++ b/src/switch.luau
@@ -15,7 +15,7 @@ local close_scope = graph.close_scope
 
 type Map<K, V> = { [K]: V }
 
-local function switch<T, U>(source: () -> T): (map: Map<T, ((() -> U)?)>) -> () -> U?
+local function switch<T, U>(source: () -> T): (map: Map<T, () -> U>) -> () -> U?
     local owner = get_owning_scope()
 
     return function(map)


### PR DESCRIPTION
Currently, the following erroneous code does not produce a type error:

```lua
local source = switch(function() return 1 end) {
    function() return 1 end,
    function() return 1 end,
}

local value = source()

if value then
    value:shouldError()
end
```

This is caused by differences in behavior between `Map<T, ((() -> U)?)>` and `Map<T, () -> U>`. This issue was resolved by replacing the former with the latter.