### PR TITLE
chore: add wally package file

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,19 @@
+[package]
+name = "centau/vide"
+description = "A reactive Luau library for creating UI. "
+license = "MIT"
+version = "0.1.0"
+registry = "https://github.com/UpliftGames/wally-index"
+realm = "shared"
+include = ["default.project.json", "LICENSE", "src"]
+exclude = [
+    ".github",
+    "docs",
+	"test",
+	".gitattributes",
+	".gitignore",
+    ".luaurc",
+	"CHANGELOG.md",
+	"README.md",
+    "todo.md"
+]


### PR DESCRIPTION
Adds the `wally.toml` file for publishing the library to the wally index.

To publish run commands from the project root:
1. `wally login`
2. `wally publish --token <token>`

More information here: https://github.com/UpliftGames/wally#wally-login---token-token