### PR TITLE
fix recursive queue flush

### DIFF
--- a/src/batch.luau
+++ b/src/batch.luau
@@ -6,17 +6,18 @@ local graph = require(script.Parent.graph)
 
 local function batch(setter: () -> ())
     local already_batching = flags.batch
+    local flush
 
-    flags.batch = true
+    if not already_batching then
+        flags.batch = true
+        flush = graph.flush_update_queue()
+    end
 
     local ok, err: string? = pcall(setter)
 
     if not already_batching then
         flags.batch = false
-        
-        if not already_batching then
-            graph.flush_update_queue()
-        end
+        flush()
     end
 
     if not ok then throw(`error occured while batching updates: {err}`) end

--- a/src/batch.luau
+++ b/src/batch.luau
@@ -16,8 +16,8 @@ local function batch(setter: () -> ())
     local ok, err: string? = pcall(setter)
 
     if not already_batching then
-        flags.batch = false
         flush()
+        flags.batch = false
     end
 
     if not ok then throw(`error occured while batching updates: {err}`) end

--- a/src/batch.luau
+++ b/src/batch.luau
@@ -6,18 +6,18 @@ local graph = require(script.Parent.graph)
 
 local function batch(setter: () -> ())
     local already_batching = flags.batch
-    local flush
+    local from
 
     if not already_batching then
         flags.batch = true
-        flush = graph.flush_update_queue()
+        from = graph.get_graph_length()
     end
 
     local ok, err: string? = pcall(setter)
 
     if not already_batching then
         flags.batch = false
-        flush()
+        graph.flush_update_queue(from)
     end
 
     if not ok then throw(`error occured while batching updates: {err}`) end

--- a/src/batch.luau
+++ b/src/batch.luau
@@ -16,8 +16,8 @@ local function batch(setter: () -> ())
     local ok, err: string? = pcall(setter)
 
     if not already_batching then
-        flush()
         flags.batch = false
+        flush()
     end
 
     if not ok then throw(`error occured while batching updates: {err}`) end

--- a/src/batch.luau
+++ b/src/batch.luau
@@ -10,7 +10,7 @@ local function batch(setter: () -> ())
 
     if not already_batching then
         flags.batch = true
-        from = graph.get_graph_length()
+        from = graph.get_update_queue_length()
     end
 
     local ok, err: string? = pcall(setter)

--- a/src/graph.luau
+++ b/src/graph.luau
@@ -184,13 +184,10 @@ local function queue_children_for_update<T>(node: SourceNode<T>)
     update_queue.n = i
 end
 
-local _flushing = false
 local function flush_update_queue()
     local n0 = update_queue.n
 
     return function()
-        assert(not _flushing, "recursive queue flush occured") -- todo
-        _flushing = true
 
         local i = n0 + 1
         while i <= update_queue.n do
@@ -204,10 +201,9 @@ local function flush_update_queue()
             update_queue[i] = false :: any
             i += 1
         end
-
+        
         update_queue.n = n0
 
-        _flushing = false
     end
 end
 

--- a/src/graph.luau
+++ b/src/graph.luau
@@ -184,7 +184,7 @@ local function queue_children_for_update<T>(node: SourceNode<T>)
     update_queue.n = i
 end
 
-local function get_graph_length()
+local function get_update_queue_length()
     return update_queue.n
 end
 
@@ -282,6 +282,6 @@ return table.freeze {
     create_source_node = create_source_node,
     get_children = get_children,
     flush_update_queue = flush_update_queue,
-    get_graph_length = get_graph_length,
+    get_update_queue_length = get_update_queue_length,
     scopes = scopes
 }

--- a/src/graph.luau
+++ b/src/graph.luau
@@ -184,27 +184,25 @@ local function queue_children_for_update<T>(node: SourceNode<T>)
     update_queue.n = i
 end
 
-local function flush_update_queue()
-    local n0 = update_queue.n
+local function get_graph_length()
+    return update_queue.n
+end
 
-    return function()
+local function flush_update_queue(from: number)
+    local i = from + 1
+    while i <= update_queue.n do
+        local node = update_queue[i]
+        --assert(node.effect)
 
-        local i = n0 + 1
-        while i <= update_queue.n do
-            local node = update_queue[i]
-            --assert(node.effect)
-
-            if node.owner and evaluate_node(node) then
-                queue_children_for_update(node)
-            end
-
-            update_queue[i] = false :: any
-            i += 1
+        if node.owner and evaluate_node(node) then
+            queue_children_for_update(node)
         end
-        
-        update_queue.n = n0
 
+        update_queue[i] = false :: any
+        i += 1
     end
+    
+    update_queue.n = from
 end
 
 local function update_descendants<T>(root: SourceNode<T>)
@@ -284,5 +282,6 @@ return table.freeze {
     create_source_node = create_source_node,
     get_children = get_children,
     flush_update_queue = flush_update_queue,
+    get_graph_length = get_graph_length,
     scopes = scopes
 }

--- a/src/graph.luau
+++ b/src/graph.luau
@@ -186,27 +186,29 @@ end
 
 local _flushing = false
 local function flush_update_queue()
-    assert(not _flushing, "recursive queue flush occured") -- todo
-    _flushing = true
+    local n0 = update_queue.n
 
-    local n0 = 0
+    return function()
+        assert(not _flushing, "recursive queue flush occured") -- todo
+        _flushing = true
 
-    local i = n0 + 1
-    while i <= update_queue.n do
-        local node = update_queue[i]
-        --assert(node.effect)
+        local i = n0 + 1
+        while i <= update_queue.n do
+            local node = update_queue[i]
+            --assert(node.effect)
 
-        if node.owner and evaluate_node(node) then
-            queue_children_for_update(node)
+            if node.owner and evaluate_node(node) then
+                queue_children_for_update(node)
+            end
+
+            update_queue[i] = false :: any
+            i += 1
         end
 
-        update_queue[i] = false :: any
-        i += 1
+        update_queue.n = n0
+
+        _flushing = false
     end
-
-    update_queue.n = n0
-
-    _flushing = false
 end
 
 local function update_descendants<T>(root: SourceNode<T>)

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1922,86 +1922,32 @@ TEST("batch()", wrap_root(function()
         CHECK(b3() == 4)
     end
 
-    do CASE "recursive queue flush"
+    do CASE "subsequent updates do not batch"
 
-        local a0 = source(0)
+        local a = source(0)
+        local b = source(0)
+        local c = source(0)
+        local d = source(0)
+        local d_n = 0
 
-        -- this effect should only update every time a0() is set
-        local changes = { a = 0, b = 0, c = 0, d = 0, e = 0 }
         effect(function()
-            a0()
-            changes.a += 1
+            c()
+            d()
+            d_n += 1
         end)
 
-        -- we first check if a0() works normally
-        a0(1)
-        CHECK(changes.a == 2)
-        a0(2)
-        CHECK(changes.a == 3)
-
-        -- we batch the sets to check if batch works normally
+        effect(function()
+            c(a())
+            d(b())
+        end)
+        
         batch(function()
-            a0(3)
-            a0(4)
-        end)
-        -- since the previous updates are batched, it should now have 3 updates in total
-        CHECK(changes.a == 4)
-
-        local b0 = source(0)
-        local b1 = source(0)
-
-        -- now lets add a effect that updates another effect
-        -- this effect tracks a0(), and updates b0() and b1() in a batch
-        -- originally, recursive queue flush would be triggered here since it
-        -- would reprocess the entire queue.
-        effect(function()
-            batch(function()
-                b0(a0())
-                b1(a0())
-            end)
-            changes.b += 1
+            a(1)
+            b(1)
         end)
 
-        local c0 = source(0)
-        local c1 = source(0)
+        CHECK(d_n == 3)
 
-        -- we add another effect that tracks b0 and b1 updates
-        -- it then updates c0 and c1, which should not be batched
-        effect(function()
-            -- this should not batch
-            c0(b0())
-            c1(b1())
-            changes.c += 1
-        end)
-
-        -- lets set a0() again to check if b0() and b1() are properly batched
-        -- this used to perform a recursive queue flush since we run batch inside
-        -- a effect previously, which would make batch rerun the effect
-        -- updating a0 once should mean effect2 only updated once
-        a0(1)
-        CHECK(changes.b == 2)
-        CHECK(changes.c == 2)
-        a0(2)
-        CHECK(changes.b == 3)
-        CHECK(changes.c == 3)
-
-        -- this tracks how often c0 and c1 are updated
-        effect(function()
-            c0()
-            c1()
-            changes.d += 1
-        end)
-
-        -- updates that happen after batch should not batch.
-        -- this checks to make sure that isn't the case
-        a0(1)
-        CHECK(changes.b == 4)
-        CHECK(changes.c == 4)
-        CHECK(changes.d == 3)
-        a0(2)
-        CHECK(changes.b == 5)
-        CHECK(changes.c == 5)
-        CHECK(changes.d == 5)
     end
 
     do CASE "recursive queue flush diamond A,B,C,D"

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1931,8 +1931,6 @@ TEST("batch()", wrap_root(function()
         end)
 
         derive(function()
-            print("update")
-
             a0()
             
             batch(function()

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1925,26 +1925,36 @@ TEST("batch()", wrap_root(function()
 
         local a0 = source(0)
         local a1 = source(1)
+        local a2 = source(0)
+        local updates = 0
 
         derive(function()
             a0(a1() + 1)
         end)
 
         derive(function()
+            updates += 1
             a0()
             
             batch(function()
+                a2(a0())
+            end)
+
+            return 1
+        end)
+
+        derive(function()
+            a2()
             
+            batch(function()
+                
             end)
 
             return 1
         end)
 
         a1(2)
-
-        -- if it didnt error, all is fine!
-        CHECK(true)
-
+        CHECK(updates == 2)
     end
 end))
 

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1920,6 +1920,34 @@ TEST("batch()", wrap_root(function()
         CHECK(b2() == 3)
         CHECK(b3() == 4)
     end
+
+    do CASE "recursive queue flush"
+
+        local a0 = source(0)
+        local a1 = source(1)
+
+        derive(function()
+            a0(a1() + 1)
+        end)
+
+        derive(function()
+            print("update")
+
+            a0()
+            
+            batch(function()
+            
+            end)
+
+            return 1
+        end)
+
+        a1(2)
+
+        -- if it didnt error, all is fine!
+        CHECK(true)
+
+    end
 end))
 
 TEST("read()", wrap_root(function()

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1842,6 +1842,7 @@ end))
 TEST("batch()", wrap_root(function()
     local source = vide.source
     local derive = vide.derive
+    local effect = vide.effect
     local batch = vide.batch
 
     do CASE "evaluation deferred"
@@ -1924,27 +1925,188 @@ TEST("batch()", wrap_root(function()
     do CASE "recursive queue flush"
 
         local a0 = source(0)
-        local a1 = source(0)
-        local updates = 0
 
-        derive(function() -- depends on a1
-            a0(a1())
-        end)
-
-        derive(function() -- batch updates a2
-            updates += 1
+        -- this effect should only update every time a0() is set
+        local changes = { a = 0, b = 0, c = 0, d = 0, e = 0 }
+        effect(function()
             a0()
-            
-            batch(function()
-
-            end)
-
-            return 1
+            changes.a += 1
         end)
 
-        a1(1)
-        CHECK(updates == 2)
+        -- we first check if a0() works normally
+        a0(1)
+        CHECK(changes.a == 2)
+        a0(2)
+        CHECK(changes.a == 3)
+
+        -- we batch the sets to check if batch works normally
+        batch(function()
+            a0(3)
+            a0(4)
+        end)
+        -- since the previous updates are batched, it should now have 3 updates in total
+        CHECK(changes.a == 4)
+
+        local b0 = source(0)
+        local b1 = source(0)
+
+        -- now lets add a effect that updates another effect
+        -- this effect tracks a0(), and updates b0() and b1() in a batch
+        -- originally, recursive queue flush would be triggered here since it
+        -- would reprocess the entire queue.
+        effect(function()
+            batch(function()
+                b0(a0())
+                b1(a0())
+            end)
+            changes.b += 1
+        end)
+
+        local c0 = source(0)
+        local c1 = source(0)
+
+        -- we add another effect that tracks b0 and b1 updates
+        -- it then updates c0 and c1, which should not be batched
+        effect(function()
+            -- this should not batch
+            c0(b0())
+            c1(b1())
+            changes.c += 1
+        end)
+
+        -- lets set a0() again to check if b0() and b1() are properly batched
+        -- this used to perform a recursive queue flush since we run batch inside
+        -- a effect previously, which would make batch rerun the effect
+        -- updating a0 once should mean effect2 only updated once
+        a0(1)
+        CHECK(changes.b == 2)
+        CHECK(changes.c == 2)
+        a0(2)
+        CHECK(changes.b == 3)
+        CHECK(changes.c == 3)
+
+        -- this tracks how often c0 and c1 are updated
+        effect(function()
+            c0()
+            c1()
+            changes.d += 1
+        end)
+
+        -- updates that happen after batch should not batch.
+        -- this checks to make sure that isn't the case
+        a0(1)
+        CHECK(changes.b == 4)
+        CHECK(changes.c == 4)
+        CHECK(changes.d == 3)
+        a0(2)
+        CHECK(changes.b == 5)
+        CHECK(changes.c == 5)
+        CHECK(changes.d == 5)
     end
+
+    do CASE "recursive queue flush diamond A,B,C,D"
+        --[[
+
+        a > b > d
+          > c >
+
+        ]]
+
+        local a = source(0)
+
+        local b = source(0)
+        local c = source(0)
+        local d = source(0)
+
+        local count = { b = 0, c = 0, d = 0 }
+        effect(function()
+            batch(function()
+                b(a() % 2 == 0 and 1 or 0)
+                c(a() * 2)
+            end)
+            count.b += 1
+            count.c += 1
+        end)
+
+        effect(function()
+            batch(function()
+                d(b() + c())
+            end)
+            count.d += 1
+        end)
+
+        a(1)
+        CHECK(count.b == 2)
+        CHECK(count.c == 2)
+        CHECK(count.d == 2)
+        CHECK(d() == 2)
+
+        a(3)
+        CHECK(count.b == 3)
+        CHECK(count.c == 3)
+        CHECK(count.d == 3)
+        CHECK(d() == 6)
+    end
+
+    do CASE "recursive queue flush diamond A,B,C,D,E"
+        --[[
+        where b and c batches d
+        
+        a > b >     e
+          > c > d >
+        
+        ]]
+
+        local a = source(0)
+
+        local b = source(0)
+        local c = source(0)
+        local d = source(0)
+        local e = source(0)
+
+        local count = { b = 0, c = 0, d = 0, e = 0 }
+        effect(function()
+            batch(function()
+                b(a() % 2 == 0 and 1 or 0)
+                c(a() * 2)
+            end)
+            count.b += 1
+            count.c += 1
+        end)
+
+        effect(function()
+            batch(function()
+                d(c() * 2)
+            end)
+            count.d += 1
+        end)
+
+        effect(function()
+            batch(function()
+                e(b() + d())
+            end)
+            count.e += 1
+        end)
+
+        CHECK(e() == 1)
+
+        a(1)
+
+        CHECK(count.b == 2)
+        CHECK(count.c == 2)
+        CHECK(count.d == 2)
+        CHECK(count.e == 3)
+        CHECK(e() == 4)
+
+        a(3)
+        CHECK(count.b == 3)
+        CHECK(count.c == 3)
+        CHECK(count.d == 3)
+        CHECK(count.e == 4)
+        CHECK(e() == 12)
+
+    end
+
 end))
 
 TEST("read()", wrap_root(function()

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -2107,6 +2107,80 @@ TEST("batch()", wrap_root(function()
 
     end
 
+    do CASE "recursive queue flush diamond A,B,C,D,E,F,G"
+--[[
+
+        a > b > d > E > G
+          > c ^   > F  
+
+        ]]
+
+        local a = source(0)
+
+        local b = source(0)
+        local c = source(0)
+        local d = source(0)
+        
+        local e = source(0)
+        local f = source(0)
+        local g = source(0)
+
+        local count = { b = 0, c = 0, d = 0, e = 0, f = 0, g = 0 }
+        effect(function()
+            batch(function()
+                b(a() % 2 == 0 and 1 or 0)
+                c(a() * 2)
+            end)
+            count.b += 1
+            count.c += 1
+        end)
+
+        effect(function()
+            batch(function()
+                d(b() + c())
+            end)
+            count.d += 1
+        end)
+
+        effect(function()
+            batch(function()
+                e(d() % 2 == 0 and 1 or 0)
+                f(d() * 2)
+            end)
+            count.e += 1
+            count.f += 1
+        end)
+
+        effect(function()
+            batch(function()
+                g(e() + f())
+            end)
+            count.g += 1
+        end)
+
+        a(1)
+        CHECK(count.b == 2)
+        CHECK(count.c == 2)
+        CHECK(count.d == 2)
+        CHECK(count.e == 2)
+        CHECK(count.f == 2)
+        CHECK(count.g == 2)
+        CHECK(d() == 2)
+        CHECK(g() == 5)
+
+        a(3)
+        CHECK(count.b == 3)
+        CHECK(count.c == 3)
+        CHECK(count.d == 3)
+        CHECK(count.e == 3)
+        CHECK(count.f == 3)
+        CHECK(count.g == 3)
+        CHECK(d() == 6)
+        CHECK(g() == 13)
+
+
+    end
+
 end))
 
 TEST("read()", wrap_root(function()

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1924,36 +1924,25 @@ TEST("batch()", wrap_root(function()
     do CASE "recursive queue flush"
 
         local a0 = source(0)
-        local a1 = source(1)
-        local a2 = source(0)
+        local a1 = source(0)
         local updates = 0
 
-        derive(function()
-            a0(a1() + 1)
+        derive(function() -- depends on a1
+            a0(a1())
         end)
 
-        derive(function()
+        derive(function() -- batch updates a2
             updates += 1
             a0()
             
             batch(function()
-                a2(a0())
+
             end)
 
             return 1
         end)
 
-        derive(function()
-            a2()
-            
-            batch(function()
-                
-            end)
-
-            return 1
-        end)
-
-        a1(2)
+        a1(1)
         CHECK(updates == 2)
     end
 end))

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1927,23 +1927,21 @@ TEST("batch()", wrap_root(function()
         local a = source(0)
         local b = source(0)
         local c = source(0)
-        local d = source(0)
         local d_n = 0
 
         effect(function()
+            b()
             c()
-            d()
             d_n += 1
         end)
 
         effect(function()
+            b(a())
             c(a())
-            d(b())
         end)
         
         batch(function()
             a(1)
-            b(1)
         end)
 
         CHECK(d_n == 3)

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -2108,7 +2108,7 @@ TEST("batch()", wrap_root(function()
     end
 
     do CASE "recursive queue flush diamond A,B,C,D,E,F,G"
---[[
+        --[[
 
         a > b > d > E > G
           > c ^   > F  


### PR DESCRIPTION
![do u know how hard it is to solve recursive queue flushing](https://github.com/user-attachments/assets/fd24e30d-885c-4adc-bff0-81ee95f57448)

fixes a bug where a effect calling batch would result in a recursive queue flush due to it updating the effect too.
also removes the error since the behavior for it changed to start flushing from when the batch call was started rather than flushing the entire update_queue