### PR TITLE
Follow the `Derivable` design pattern for all props

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -6,7 +6,5 @@ export type source<T> = vide.source<T>
 export type Source<T> = vide.Source<T>
 export type context<T> = vide.context<T>
 export type Context<T> = vide.Context<T>
-export type CanBe<T> = T | () -> T
-export type canBe<T> = T | () -> T
 
 return vide

--- a/src/init.luau
+++ b/src/init.luau
@@ -6,5 +6,7 @@ export type source<T> = vide.source<T>
 export type Source<T> = vide.Source<T>
 export type context<T> = vide.context<T>
 export type Context<T> = vide.Context<T>
+export type CanBe<T> = T | () -> T
+export type canBe<T> = T | () -> T
 
 return vide

--- a/src/read.luau
+++ b/src/read.luau
@@ -1,6 +1,4 @@
-local source = require(script.Parent.source)
-
-local function read<T>(value: source.Source<T> | T): T
+local function read<T>(value: ((() -> T) & ((value: T) -> T)) | T): T
 	return if typeof(value) == "function" then value() else value
 end
 

--- a/src/read.luau
+++ b/src/read.luau
@@ -1,4 +1,4 @@
-local function read<T>(value: ((() -> T) & ((value: T) -> T)) | T): T
+local function read<T>(value: (() -> T) | T): T
 	return if typeof(value) == "function" then value() else value
 end
 

--- a/src/read.luau
+++ b/src/read.luau
@@ -1,5 +1,5 @@
 local function read<T>(value: (() -> T) | T): T
-	return if typeof(value) == "function" then value() else value
+	return if type(value) == "function" then value() else value
 end
 
 return read

--- a/src/read.luau
+++ b/src/read.luau
@@ -1,5 +1,7 @@
-local function read<T>(value: T | () -> T): T
-    return if type(value) == "function" then value() else value
+local source = require(script.Parent.source)
+
+local function read<T>(value: source.Source<T> | T): T
+	return if typeof(value) == "function" then value() else value
 end
 
 return read


### PR DESCRIPTION
Reduces un-neccesary definitions of the type accross the codebase of users
Willing to add `can` alias if enough ask for it, although having a bit of opinionation never hurt anyone, not exactly like fusion has a `Used` alias for `UsedAs`