### PR TITLE
add Camera and WorldModel to list of instances recognized by `vide.cr…

### DIFF
--- a/src/create.luau
+++ b/src/create.luau
@@ -65,6 +65,8 @@ type Instances = {
     UIGradient: UIGradient,
     UIGridLayout: UIGridLayout,
     UIListLayout: UIListLayout,
+    Camera: Camera,
+    WorldModel: WorldModel,
 }
 
 type function Properties(instance: type?)


### PR DESCRIPTION
add Camera and WorldModel to list of instances recognized by `vide.create`

these instances are commonly used when working with viewport frames within UIs