### PR TITLE
Fix nilable source overload typing

### DIFF
--- a/src/source.luau
+++ b/src/source.luau
@@ -4,7 +4,7 @@ local create_source_node = graph.create_source_node
 local push_scope_as_child_of = graph.push_scope_as_child_of
 local update_descendants = graph.update_descendants
 
-export type Source<T> = (() -> T) & ((value: T) -> T)
+export type Source<T> = (() -> T) & (<U>(value: U & T) -> U & T)
 
 local function source<T>(initial_value: T): Source<T>
     local node = create_source_node(initial_value)
@@ -25,7 +25,7 @@ local function source<T>(initial_value: T): Source<T>
         return v
     end
 
-    return update_source
+    return update_source :: Source<T>
 end
 
 return source :: (<T>(initial_value: T) -> Source<T>) & (<T>() -> Source<T>)


### PR DESCRIPTION
Using Vide sources under the new typesolver currently presents this LSP warning:
```
TypeError: Calling function (() -> string?) & ((string?) -> string?) with argument pack () is ambiguous.
```

This could be a Luau bug, I've opened a PR there to resolve this issue upstream in that case:
https://github.com/luau-lang/luau/pull/2410

However, the Luau team may decide this is intended behaviour and not merge the change.
For now, to unblock Vide users on the new type solver, I've adjusted the sources type.

I modeled the setter side of `Source<T>` as a generic intersection with `T`, which preserves valid writes, including `nil` for nilable sources, while preventing it from competing with the getter overload for zero-argument reads.

The returned closure is cast to `Source<T>` inside the factory because the runtime implementation is one variadic function that branches on `select("#", ...)`, while the public type is an overloaded callable intersection.

Fixes https://github.com/centau/vide/issues/71