### PR TITLE
feat: add additional UI types to Vide Instances type

### DIFF
--- a/src/create.luau
+++ b/src/create.luau
@@ -70,6 +70,9 @@ type Instances = {
     UIGradient: UIGradient,
     UIGridLayout: UIGridLayout,
     UIListLayout: UIListLayout,
+    UIPadding: UIPadding,
+    UIScale: UIScale,
+    UIStroke: UIStroke,
     Camera: Camera,
     WorldModel: WorldModel,
 }


### PR DESCRIPTION
## Change Summary + Screenshots

Added `UIPadding`, `UIStroke`, and `UIScale` to the `Instances` type in `create.luau` to resolve type errors when creating these UI constraint instances.

before:
<img width="480" height="220" alt="image" src="https://github.com/user-attachments/assets/a740e737-0d6d-46e5-97d2-8948d5942fb3" />
<img width="571" height="284" alt="image" src="https://github.com/user-attachments/assets/d339f257-49da-43f6-bdf4-ca4722a0db9a" />
<img width="550" height="192" alt="image" src="https://github.com/user-attachments/assets/108004b9-51a5-436b-9f22-528729e8e73b" />

after:
<img width="441" height="163" alt="image" src="https://github.com/user-attachments/assets/035adbfb-c27f-435d-b2cc-2e17b96ee6b4" />
<img width="486" height="202" alt="image" src="https://github.com/user-attachments/assets/7f3f37cc-e20b-4471-800e-ce42fc458284" />
<img width="406" height="104" alt="image" src="https://github.com/user-attachments/assets/1c9516b1-2d3b-4292-ae8a-f3c0ae8565c8" />