### PR TITLE
feat: add CanBeSource type

### DIFF
--- a/docs/api/reactivity-utility.md
+++ b/docs/api/reactivity-utility.md
@@ -74,7 +74,9 @@ Utility used to read a value that is either a primitive or a source.
 - **Type**
 
     ```luau
-    function read<T>(value: T | () -> T): T
+    type CanBeSource<T> = T | (() -> T)
+
+    function read<T>(value: CanBeSource<T>): T
     ```
 
 ## batch()

--- a/init.luau
+++ b/init.luau
@@ -2,7 +2,7 @@ local vide = require "@self/src/lib"
 
 export type source<T> = vide.source<T>
 export type Source<T> = vide.Source<T>
-export type CanBeSource<T> = read.CanBeSource<T>
+export type CanBeSource<T> = vide.CanBeSource<T>
 export type context<T> = vide.context<T>
 export type Context<T> = vide.Context<T>
 export type Instances = vide.Instances

--- a/init.luau
+++ b/init.luau
@@ -2,6 +2,7 @@ local vide = require "@self/src/lib"
 
 export type source<T> = vide.source<T>
 export type Source<T> = vide.Source<T>
+export type CanBeSource<T> = read.CanBeSource<T>
 export type context<T> = vide.context<T>
 export type Context<T> = vide.Context<T>
 export type Instances = vide.Instances

--- a/src/init.luau
+++ b/src/init.luau
@@ -4,6 +4,7 @@ local vide = require("@self/lib")
 
 export type source<T> = vide.source<T>
 export type Source<T> = vide.Source<T>
+export type CanBeSource<T> = vide.CanBeSource<T>
 export type context<T> = vide.context<T>
 export type Context<T> = vide.Context<T>
 export type Instances = vide.Instances

--- a/src/lib.luau
+++ b/src/lib.luau
@@ -25,6 +25,7 @@ local flags = require "./flags"
 
 export type Source<T> = source.Source<T>
 export type source<T> = Source<T>
+export type CanBeSource<T> = read.CanBeSource<T>
 export type Context<T> = context.Context<T>
 export type context<T> = Context<T>
 export type Instances = create.Instances

--- a/src/read.luau
+++ b/src/read.luau
@@ -1,4 +1,6 @@
-local function read<T>(value: T | () -> T): T
+export type CanBeSource<T> = T | (() -> T)
+
+local function read<T>(value: CanBeSource<T>): T
     return if type(value) == "function" then value() else value
 end
 


### PR DESCRIPTION
Adds and exports `CanBeSource<T>` for static or reactive values, so consumers no longer need to redefine `T | (() -> T)`. Updates `read()` and its documentation to use the new type. 